### PR TITLE
Remove duplicate minting trait bound

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use system;
 mod mock;
 mod tests;
 
-pub trait Trait: system::Trait + minting::Trait + minting::Trait {
+pub trait Trait: system::Trait + minting::Trait {
     type PayoutStatusHandler: PayoutStatusHandler<Self>;
 
     /// Type of identifier for recipients.


### PR DESCRIPTION
Hoping this resolves a downstream trait issue in runtime.